### PR TITLE
Fixes Issue #1

### DIFF
--- a/src/cpp/TypeChecker.cpp
+++ b/src/cpp/TypeChecker.cpp
@@ -400,7 +400,7 @@ Type* TypeChecker::typeCheck(Node* tree) {
 						freeType(typeCheck(tree->node_data.nodes[2]));
 					}
 
-					if(!analyzer->isPrimitiveTypeBool(ret) && !analyzer->isPrimitiveTypeNum(ret)) {
+					if(!analyzer->isPrimitiveTypeNum(ret) && !analyzer->isPrimitiveTypeBool(ret)) {
 						expectedstring = "Bool"; freeType(ret);
 						ret = MakeType(TYPE_CLASS);
 						ret->typedata._class.classname = strdup("Bool");


### PR DESCRIPTION
Allowed isPrimitiveTypeNum as well as iPTBool. The type after an error is still a bool, though.
