### PR TITLE
Logical Operators vs Bitwise Operators

### DIFF
--- a/src/cpp/ObjectFileGenerator.cpp
+++ b/src/cpp/ObjectFileGenerator.cpp
@@ -824,7 +824,7 @@ void ObjectFileGenerator::generate(Node* tree) {
 		case NT_AND:
 			file << "(";
 			generate(tree->node_data.nodes[0]);
-			file << "&";
+			file << "&&";
 			generate(tree->node_data.nodes[1]);
 			file << ")";
 			break;
@@ -832,7 +832,7 @@ void ObjectFileGenerator::generate(Node* tree) {
 		case NT_OR:
 			file << "(";
 			generate(tree->node_data.nodes[0]);
-			file << "|";
+			file << "||";
 			generate(tree->node_data.nodes[1]);
 			file << ")";
 			break;


### PR DESCRIPTION
Code generation was using Bitwise instead of Logical ands and ors.  Switched thes to logical to take advantage of short curcuit evaluation.