### PR TITLE
Code Gen Precision

### DIFF
--- a/src/cpp/ObjectFileGenerator.cpp
+++ b/src/cpp/ObjectFileGenerator.cpp
@@ -901,7 +901,7 @@ void ObjectFileGenerator::generate(Node* tree) {
 			break;
 
 		case NT_NUMBERLIT:
-			file << std::setprecision (std::numeric_limits<double>::digits10 + 1) << tree->node_data.number;
+			file << std::setprecision (std::numeric_limits<double>::digits10 + 2) << tree->node_data.number;
 			break;
 
 		case NT_BOOLLIT: file << (tree->node_data.number ? "1" : "0"); break;

--- a/src/wake/test/PrecisionTest.wk
+++ b/src/wake/test/PrecisionTest.wk
@@ -18,3 +18,8 @@ every PrecisionTest is:
 			Asserts.fail("couldn't parse double from " + Text);
 		}
 	}
+	
+	@Test
+	floatingPointOperationsAreCorrect(Asserts) {
+		Asserts.that(0xB5EA16DE19771p-49 + 0x6487ED5110B46p-49)Equals(0x11a72042f2a2b7p-49.0);
+	}


### PR DESCRIPTION
Added a digit to code gen number output.  Now all floats can go from binary -> decimial -> same binary.